### PR TITLE
Do not emit grammar node inside root node

### DIFF
--- a/rnc2rng/serializer.py
+++ b/rnc2rng/serializer.py
@@ -25,6 +25,7 @@ class XMLSerializer(object):
     def reset(self):
         self.buf = []
         self.needs = {}
+        self.types = None
         self.ns = {}
         self.default = ''
         self.level = 0
@@ -45,6 +46,7 @@ class XMLSerializer(object):
         for n in node.value:
             if n.type == DATATYPES:
                 types = n.value[0].strip('"')
+                self.types = types
             elif n.type == DEFAULT_NS:
                 self.default = n.value[0].strip('"')
                 if n.name is not None:
@@ -222,9 +224,23 @@ class XMLSerializer(object):
                 self.visit(x.value)
                 self.write('</attribute>')
             elif x.type == ROOT:
-                src = XMLSerializer(self.indent).toxml(x)
-                for ln in src.splitlines()[1:]:
-                    self.write(ln)
+                # Verify the included document has the same metadata
+                for n in x.value:
+                    if n.type == DATATYPES:
+                        types = n.value[0].strip('"')
+                        assert types == self.types
+                    elif n.type == DEFAULT_NS:
+                        default = n.value[0].strip('"')
+                        assert default == self.default
+                    elif n.type == NS:
+                        assert n.name in self.ns
+                        assert n.value[0].strip(' "') == self.ns[n.name]
+
+                if indent:
+                    self.level -= 1
+                self.visit(x.value)
+                if indent:
+                    self.level += 1
             else:
                 assert False, x
         if indent:

--- a/tests/include.rnc
+++ b/tests/include.rnc
@@ -1,1 +1,3 @@
+datatypes xsd = "http://www.w3.org/2001/XMLSchema-datatypes"
+include "datatypes.rnc"
 include "simple.rnc"

--- a/tests/include.rng
+++ b/tests/include.rng
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0">
-  <grammar xmlns="http://relaxng.org/ns/structure/1.0">
-    <start>
-      <element>
-        <name ns="">foo</name>
-        <text/>
-      </element>
-    </start>
-  </grammar>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <start>
+    <element>
+      <name ns="">height</name>
+      <data type="double"/>
+    </element>
+  </start>
+  <start>
+    <element>
+      <name ns="">foo</name>
+      <text/>
+    </element>
+  </start>
 </grammar>


### PR DESCRIPTION
XMLSerializer always emits a grammar node as the root node.
As a result, no other grammar nodes may be emitted as children.

For each included rnc, validate the included root attributes are
present in the main root document, and process the included
rnc without its root attribute.
