### PR TITLE
Support tilde token for concatenation of string literals

### DIFF
--- a/tests/ns-concat.rnc
+++ b/tests/ns-concat.rnc
@@ -1,0 +1,6 @@
+namespace rng = "http://"
+  ~ "relaxng.org/"
+  ~ "ns/"
+  ~ "structure/"
+  ~ "1.0"
+element rng:text { empty }

--- a/tests/ns-concat.rng
+++ b/tests/ns-concat.rng
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:rng="http://relaxng.org/ns/structure/1.0">
+  <start>
+    <element>
+      <name ns="http://relaxng.org/ns/structure/1.0">text</name>
+      <empty/>
+    </element>
+  </start>
+</grammar>


### PR DESCRIPTION
My read of the RELAX NG Compact Syntax spec indicates that two string literals should be concatenated when immediately surrounding a tilde.  This is not currently supported by rnc2rng but could be useful.  As one example, Appendix B to RFC 4278 (ATOM syndication) utilizes several tildes and concatenation would be expected.  PR to include support in parser.py and add a simple test.    