### PR TITLE
Fix filepath handling and documentation parsing on Windows

### DIFF
--- a/rnc2rng/parser.py
+++ b/rnc2rng/parser.py
@@ -540,7 +540,7 @@ def name_class_group(s, p):
 @pg.production('documentations : DOCUMENTATION documentations')
 def documentations_multi(s, p):
     cur = Node('DOCUMENTATION', None, []) if not p[1] else p[1][0]
-    cur.value.insert(0, p[0].value.lstrip('# '))
+    cur.value.insert(0, p[0].value.lstrip('# ').rstrip('\r'))
     return [cur]
 
 @pg.production('documentations : ')


### PR DESCRIPTION
Fix #31 and fix #33.

Tests now pass on my Windows machine under both Python 2.7 and 3.8.

Happy to split this PR if that is preferred. The fix for #33 is a one-liner.