### PR TITLE
Use GITHUB_TOKEN per coveralls 3.3.1 help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install coverage coveralls rply
     - name: Test coverage
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         coverage run test.py
-        COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }} coveralls
+        coveralls --service=github


### PR DESCRIPTION
Getting the following error

   Running on Github Actions but GITHUB_TOKEN is not set.
   Add "env: GITHUB_TOEKN: ${{ secrets.GITHUB_TOKEN }}" to
   your step config.

Following directions from latest coveralls python (3.3.1) help
for Github Actions
https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html#github-actions-support