### PR TITLE
Update Python Test Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.7, 3.8, 3.9]
+        python: [3.8, 3.9, 3.10, 3.11, 3.12]
         include:
           - os: macos-latest
-            python: 3.9
+            python: 3.12
           - os: windows-latest
-            python: 3.9
+            python: 3.12
 
     runs-on: ${{ matrix.os }}
 
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python: 3.9
+        python: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.8, 3.9, 3.10, 3.11, 3.12]
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
         include:
           - os: macos-latest
-            python: 3.12
+            python: '3.12'
           - os: windows-latest
-            python: 3.12
+            python: '3.12'
 
     runs-on: ${{ matrix.os }}
 
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v1
       with:
-        python: 3.12
+        python: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ RELAX NG Compact to RELAX NG conversion library
 Converts RELAX NG schemata in Compact syntax (`rnc`) to the equivalent schema
 in the XML-based default RELAX NG syntax. Dependencies:
 
-- Python 3.x (tested with 3.7, 3.8, 3.9)
+- Python 3.x (tested with 3.8, 3.9, 3.10, 3.11, 3.12)
 - `rply`_
 
 Feedback welcome on `GitHub`_. Please consider funding continued maintenance of this

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Text Processing :: Markup :: XML',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     packages=['rnc2rng'],
     entry_points={


### PR DESCRIPTION
Based on https://devguide.python.org/versions/#supported-versions Fixes #48

Remove 3.7 (EOL 2023-06-27)
Add 3.10, 3.11, 3.12