### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
-        python: ${{ matrix.python }}
+        python-version: ${{ matrix.python }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -41,11 +41,11 @@ jobs:
   Coverage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python 3.12
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
-        python: '3.12'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Update actions to latest version
 - checkout v4
 - setup-python v5
   - use python-version instead of python per basic usage instructions https://github.com/marketplace/actions/setup-python#basic-usage
   - also resolves warnings while running job `Unexpected input(s) 'python', valid inputs are ['python-version', 'architecture']`