### PR TITLE
Remove useless shebangs, execute bits

### DIFF
--- a/rnc2rng/__main__.py
+++ b/rnc2rng/__main__.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import print_function
 from . import parser, serializer
 import sys

--- a/rnc2rng/rnctree.py
+++ b/rnc2rng/rnctree.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Compatibility API for rnc2rng 1.0
 from . import parser, serializer
 


### PR DESCRIPTION
For `rnctree.py`, the shebang line is *clearly* useless: this module is not script-like. It does not have the execute bit set in its filesystem permissions, it does not have a “main routine,” and it has no interesting side effects.

For `__main__.py`, it may have been useful to run this as `python3 ./rnc2rng/__main__.py` during development at one point in this project’s history, but this is no longer viable:

```
$ python3 ./rnc2rng/__main__.py
Traceback (most recent call last):
  File "/home/ben/src/forks/rnc2rng/./rnc2rng/__main__.py", line 3, in <module>
    from . import parser, serializer
ImportError: attempted relative import with no known parent package
```

Let’s just drop the shebang and execute bit here, too. One can always run `python3 -m rnc2rng` instead.