### PR TITLE
Update Python versions to 3.10-3.14 and use unittest runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14']
         include:
           - os: macos-latest
             python: '3.12'
@@ -36,7 +36,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run tests
-      run: python test.py
+      run: python -m unittest
 
   Coverage:
     runs-on: ubuntu-latest
@@ -54,5 +54,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        coverage run test.py
+        coverage run -m unittest
         coveralls --service=github

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ RELAX NG Compact to RELAX NG conversion library
 Converts RELAX NG schemata in Compact syntax (`rnc`) to the equivalent schema
 in the XML-based default RELAX NG syntax. Dependencies:
 
-- Python 3.x (tested with 3.8, 3.9, 3.10, 3.11, 3.12)
+- Python 3.x (tested with 3.10, 3.11, 3.12, 3.13, 3.14)
 - `rply`_
 
 Feedback welcome on `GitHub`_. Please consider funding continued maintenance of this

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Text Processing :: Markup :: XML',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     packages=['rnc2rng'],
     entry_points={

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -2,6 +2,7 @@ import rnc2rng
 import unittest
 from urllib.parse import urlparse
 from urllib.request import url2pathname
+from pathlib import Path
 import importlib.resources as resources
 from . import golden
 
@@ -22,6 +23,8 @@ class TestSuite(unittest.TestCase):
         if ref.startswith("file:"):
             parse_result = urlparse(ref)
             ref = url2pathname(parse_result.path)
+        # Extract just the filename for resources.open_text
+        ref = Path(ref).name
         with resources.open_text(golden, ref) as expect_src:
             expected = expect_src.read().rstrip()
             actual = rnc2rng.dumps(root).strip()


### PR DESCRIPTION
- Change ci.yml matrix from 3.8-3.12 to 3.10-3.14
- Update ci.yml test commands to use python -m unittest
- Update ci.yml coverage to use coverage run -m unittest
- Update setup.py classifiers to 3.10-3.14
- Update README.rst to document tested versions 3.10-3.14